### PR TITLE
Update broken debug-physics.js

### DIFF
--- a/playcanvas-devtools/debug-physics.js
+++ b/playcanvas-devtools/debug-physics.js
@@ -185,7 +185,7 @@ DebugPhysics.prototype.postUpdate = function (dt) {
 
                 // Use the rigid body position if we have it
                 if (collision.entity.rigidbody) {
-                    var body = collision.entity.rigidbody.data.body;
+                    var body = collision.entity.rigidbody.body;
                     if (body) {
                         var t = body.getWorldTransform();
 


### PR DESCRIPTION
RigidBodyComponent class was changed in engine build v1.42.0 (the component data properties were moved into the core RigidBodyComponent, see  https://github.com/playcanvas/engine/pull/3164 for more details), Since then, the debug-physics.js has been broken, as the "data" property became undefined.
This pull request fixes the issue.